### PR TITLE
#22: lodash should not be a dependency (closes #22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "react": ">= 0.12.x"
   },
   "dependencies": {
-    "lodash": "^4.6.1",
     "tcomb-react": "^0.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,7 +2542,7 @@ lodash@^3.10.0, lodash@^3.2.0, lodash@^3.8.0, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
@@ -3248,8 +3248,8 @@ readable-stream@^1.0.27-1, readable-stream@^1.1.13:
     string_decoder "~0.10.x"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.0.tgz#bb2d810631416edf095ebdadc246f68cec65bf2c"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.1.tgz#c459a6687ad6195f936b959870776edef27a7655"
   dependencies:
     buffer-shims "^1.0.0"
     core-util-is "~1.0.0"


### PR DESCRIPTION
Issue #22

## Test Plan

### tests performed
- `rm -rf node_modules && npm i && npm start` -> examples work fine

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
