### PR TITLE
Adds support for input DOM inner reference, updates example & README.md

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -65,7 +65,7 @@ class Example extends React.Component {
       <div style={{ width: 350, margin: 20 }}>
 
         <h2>Plain text</h2>
-        <InputChildren style={inputStyle} placeholder='right padding is computed'>
+        <InputChildren style={inputStyle} placeholder='right padding is computed' innerRef={(ref) => { this.firstInput = ref; }} >
           <a style={linkStyle} onClick={this.toggleLength}>{this.state.firstLinkText}</a>
         </InputChildren>
 

--- a/src/InputChildren.js
+++ b/src/InputChildren.js
@@ -20,7 +20,8 @@ export default class InputChildren extends React.Component {
       React.PropTypes.node,
       React.PropTypes.element
     ]),
-    wrapper: React.PropTypes.object
+    wrapper: React.PropTypes.object,
+    innerRef: React.PropTypes.func
   }
 
   static defaultProps = {
@@ -71,6 +72,7 @@ export default class InputChildren extends React.Component {
     const {
       children,
       wrapper,
+      innerRef,
       ...inputProps
     } = this.props;
 
@@ -84,7 +86,7 @@ export default class InputChildren extends React.Component {
 
     return (
       <div {...wrapperProps}>
-        <input {...inputProps} style={this.getInputStyle()} />
+        <input {...inputProps} style={this.getInputStyle()} ref={innerRef} />
         <div ref='childrenWrapper' style={this.getChildrenStyle()}>
           {children}
         </div>

--- a/src/README.md
+++ b/src/README.md
@@ -8,3 +8,4 @@ a child (link, button...) inside the input itself. It supports the same props of
 |----|----|-------|-----------|
 | **children** | <code>ReactChildren</code> |  | *optional*. React children rendered inside the input |
 | **wrapper** | <code>Object</code> | <code>{}</code> | *optional*. Props passed to wrapper 'div' |
+| **innerRef** | <code>Function</code> |  | *optional*. Ref function for internal input reference <br /><code>(ref) => { this.input = ref; }</code> |


### PR DESCRIPTION
Closes #31 

Short and simple PR for <input /> element inner reference.