### PR TITLE
drop support for older react versions (<0.14.9), support react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,10 @@
     "webpack-dev-server": "^1.14.1"
   },
   "peerDependencies": {
-    "react": ">= 0.12.x"
+    "react": ">=0.14.9 <15 || >=15.3.x"
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "tcomb-react": "^0.9.3"
   }
 }

--- a/src/InputChildren.js
+++ b/src/InputChildren.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { t, props } from 'tcomb-react';
 
 export const Props = {
@@ -16,12 +17,12 @@ export const Props = {
 export default class InputChildren extends React.Component {
 
   static propTypes = {
-    children: React.PropTypes.oneOfType([
-      React.PropTypes.node,
-      React.PropTypes.element
+    children: PropTypes.oneOfType([
+      PropTypes.node,
+      PropTypes.element
     ]),
-    wrapper: React.PropTypes.object,
-    innerRef: React.PropTypes.func
+    wrapper: PropTypes.object,
+    innerRef: PropTypes.func
   }
 
   static defaultProps = {


### PR DESCRIPTION
Closes #34 

Followed instructions [here](https://github.com/facebook/prop-types#how-to-depend-on-this-package) and [here](https://github.com/facebook/prop-types#compatibility)

Not sure what's going to happen to the generated readme 👼 