### PR TITLE
#47: computeChildrenSize in didMount/update can cause React stack overflows (closes #47)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/enzyme": "2.8.6",
     "@types/jest": "20.0.7",
     "@types/node": "8.0.54",
-    "@types/prop-types": "15.5.2",
     "@types/react": "^16.0.25",
     "babel-loader": "^7.1.2",
     "babel-preset-buildo": "^0.1.1",
@@ -70,9 +69,7 @@
   "peerDependencies": {
     "react": ">= 15"
   },
-  "dependencies": {
-    "prop-types": "^15.6.0"
-  },
+  "dependencies": {},
   "jest": {
     "setupFiles": [
       "<rootDir>/test/setup.js"

--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -23,23 +23,25 @@ export type State = {
 export class InputChildren extends React.Component<InputChildren.Props, State> {
   state = { width: 1, height: 1 }
 
-  childrenWrapper: HTMLDivElement
+  childrenWrapper: HTMLDivElement | null = null;
 
   componentDidMount() {
     this.computeChildrenSize();
   }
 
-  computeChildrenSize(): void {
-    const { clientWidth, clientHeight } = this.childrenWrapper;
-    if (clientWidth !== this.state.width || clientHeight !== this.state.height) {
-      this.setState({
-        height: clientHeight,
-        width: clientWidth
-      });
+  computeChildrenSize = () : void => {
+    if (this.childrenWrapper) {
+      const { clientWidth, clientHeight } = this.childrenWrapper;
+      if (clientWidth !== this.state.width || clientHeight !== this.state.height) {
+        this.setState({
+          height: clientHeight,
+          width: clientWidth
+        });
+      }
     }
   }
 
-  getInputStyle(): React.CSSProperties {
+  getInputStyle = (): React.CSSProperties => {
     return {
       ...this.props.style,
       paddingRight: this.state.width,
@@ -48,7 +50,7 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
     };
   }
 
-  getChildrenStyle(): React.CSSProperties {
+  getChildrenStyle = (): React.CSSProperties => {
     return {
       position: 'absolute',
       top: '50%',
@@ -84,7 +86,7 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
   }
 
   componentDidUpdate() {
-    this.computeChildrenSize();
+    setTimeout(this.computeChildrenSize);
   }
 
 }

--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -24,6 +24,7 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
   state = { width: 1, height: 1 }
 
   childrenWrapper: HTMLDivElement | null = null;
+  computeTimeout: number | null = null
 
   componentDidMount() {
     this.computeChildrenSize();
@@ -86,7 +87,12 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
   }
 
   componentDidUpdate() {
-    setTimeout(this.computeChildrenSize);
+    this.computeTimeout = setTimeout(this.computeChildrenSize);
   }
 
+  componentWillUnmount() {
+    if (this.computeTimeout !== null) {
+      clearTimeout(this.computeTimeout)
+    }
+  }
 }

--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export namespace InputChildren {
   export type Props = React.HTMLProps<HTMLInputElement> & {
@@ -22,16 +21,6 @@ export type State = {
  * a child (link, button...) inside the input itself. It supports the same props of react input.
  */
 export class InputChildren extends React.Component<InputChildren.Props, State> {
-
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.element
-    ]),
-    wrapper: PropTypes.object,
-    innerRef: PropTypes.func
-  }
-
   state = { width: 1, height: 1 }
 
   childrenWrapper: HTMLDivElement


### PR DESCRIPTION
Closes [#2520612](https://buildo.kaiten.io/space/32111/card/2520612)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #47

Didn't really test "the fix", because I wasn't able to reproduce the original issue properly.
The behavior of this component (correctly measuring children and adding internal padding to the input) looks perfectly preserved in the average cases that I tested.

_Note: even if unrelated, this PR also removes runtime React `PropTypes` checking, as we recently did for many other react components_