### PR TITLE
Revert "#47: computeChildrenSize in didMount/update can cause React stack overflows (closes #47)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/enzyme": "2.8.6",
     "@types/jest": "20.0.7",
     "@types/node": "8.0.54",
-    "@types/prop-types": "15.5.2",
     "@types/react": "^16.0.25",
     "babel-loader": "^7.1.2",
     "babel-preset-buildo": "^0.1.1",
@@ -70,9 +69,7 @@
   "peerDependencies": {
     "react": ">= 15"
   },
-  "dependencies": {
-    "prop-types": "^15.6.0"
-  },
+  "dependencies": {},
   "jest": {
     "setupFiles": [
       "<rootDir>/test/setup.js"

--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 
 export namespace InputChildren {
   export type Props = React.HTMLProps<HTMLInputElement> & {
@@ -22,16 +21,6 @@ export type State = {
  * a child (link, button...) inside the input itself. It supports the same props of react input.
  */
 export class InputChildren extends React.Component<InputChildren.Props, State> {
-
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.element
-    ]),
-    wrapper: PropTypes.object,
-    innerRef: PropTypes.func
-  }
-
   state = { width: 1, height: 1 }
 
   childrenWrapper: HTMLDivElement


### PR DESCRIPTION
Reverts buildo/react-input-children#48