### PR TITLE
#47: computeChildrenSize in didMount/update can cause React stack overflows (closes #47)

### DIFF
--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -31,7 +31,14 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
 
   computeChildrenSize(): void {
     const { clientWidth, clientHeight } = this.childrenWrapper;
-    if (clientWidth !== this.state.width || clientHeight !== this.state.height) {
+    if (
+      // Instead of plain !== comparison, using a magic number
+      // to defend against possible rounding errors in
+      // `clientHeight`/`clientWidth`, and avoid causing re-render loops.
+      // See https://github.com/buildo/react-input-children/issues/47
+      Math.abs(clientWidth - this.state.width) > 1 ||
+      Math.abs(clientHeight - this.state.height) > 1
+    ) {
       this.setState({
         height: clientHeight,
         width: clientWidth


### PR DESCRIPTION
Closes [#2520612](https://buildo.kaiten.io/space/32111/card/2520612)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #47

See https://github.com/buildo/react-input-children/issues/47#issuecomment-608812405

## Test Plan

tested this fixes the loop in the "80% zoom repro"