### PR TITLE
#51: forward React ref to the underlying input element

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "build": "rm -rf lib && mkdir lib && tsc",
     "preversion": "npm run test",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "start": "styleguidist server",
     "typecheck": "tsc --noEmit",
     "release-version": "smooth-release"
@@ -42,8 +42,7 @@
   "devDependencies": {
     "@types/enzyme": "2.8.6",
     "@types/jest": "20.0.7",
-    "@types/node": "8.0.54",
-    "@types/react": "^16.0.25",
+    "@types/react": "^16.9.34",
     "babel-loader": "^7.1.2",
     "babel-preset-buildo": "^0.1.1",
     "css-loader": "^0.28.5",
@@ -51,23 +50,22 @@
     "enzyme-adapter-react-16": "1.1.0",
     "file-loader": "^1.1.5",
     "jest": "^21.2.1",
-    "node-sass": "4.5.2",
     "progress-bar-webpack-plugin": "^1.10.0",
     "raw-loader": "^0.5.1",
-    "react": "^16",
+    "react": "^16.13.1",
     "react-docgen-typescript": "^1.1.0",
-    "react-dom": "^16",
+    "react-dom": "^16.13.1",
     "react-styleguidist": "^6.0.33",
-    "react-test-renderer": "^16.2.0",
+    "react-test-renderer": "^16.13.1",
     "sass-loader": "^6.0.6",
     "smooth-release": "^8.0.4",
     "ts-jest": "^21.2.3",
     "ts-loader": "^2.3.3",
-    "typescript": "^2.4.2",
+    "typescript": "^3.8.3",
     "webpack": "3.5.5"
   },
   "peerDependencies": {
-    "react": ">= 15"
+    "react": ">= 16"
   },
   "dependencies": {},
   "jest": {

--- a/src/InputChildren.tsx
+++ b/src/InputChildren.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 export namespace InputChildren {
-  export type Props = React.HTMLProps<HTMLInputElement> & {
+  export type Props = Omit<React.HTMLProps<HTMLInputElement>, 'ref'> & {
     /** React children rendered inside the input */
     children?: React.ReactNode,
     /** Props passed to wrapper 'div' */
     wrapper?:  React.HTMLProps<HTMLDivElement>
     /** Ref function for internal input reference */
-    innerRef?: (input: HTMLInputElement) => void
+    inputRef?: React.Ref<HTMLInputElement>
   }
 }
 
@@ -16,11 +16,7 @@ export type State = {
   height: number
 }
 
-/**
- * `InputChildren` is a replacement for the base input react component capable of rendering
- * a child (link, button...) inside the input itself. It supports the same props of react input.
- */
-export class InputChildren extends React.Component<InputChildren.Props, State> {
+class InputChildrenInternal extends React.Component<InputChildren.Props, State> {
   state = { width: 1, height: 1 }
 
   childrenWrapper: HTMLDivElement
@@ -68,7 +64,7 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
     const {
       children,
       wrapper = {},
-      innerRef,
+      inputRef,
       ...inputProps
     } = this.props;
 
@@ -82,7 +78,7 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
 
     return (
       <div {...wrapperProps}>
-        <input {...inputProps} style={this.getInputStyle()} ref={innerRef} />
+        <input {...inputProps} style={this.getInputStyle()} ref={inputRef} />
         <div ref={(ref: HTMLDivElement) => this.childrenWrapper = ref} style={this.getChildrenStyle()}>
           {children}
         </div>
@@ -95,3 +91,11 @@ export class InputChildren extends React.Component<InputChildren.Props, State> {
   }
 
 }
+
+/**
+ * `InputChildren` is a replacement for the base input react component capable of rendering
+ * a child (link, button...) inside the input itself. It supports the same props of react input.
+ */
+export const InputChildren = React.forwardRef<HTMLInputElement, InputChildren.Props>(
+  (props, ref) => <InputChildrenInternal {...props} inputRef={ref} />
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES3",
+    "target": "ES5",
     "module": "commonjs",
     "declaration": true,
     "allowSyntheticDefaultImports": false,
@@ -16,9 +16,7 @@
     "sourceMap": false,
     "alwaysStrict": true,
     "jsx": "react",
-    "lib": [
-      "dom", "es6"
-    ]
+    "lib": ["dom", "esnext"]
   },
   "include": [
     "src/*",


### PR DESCRIPTION
Closes [#2520582](https://buildo.kaiten.io/space/32111/card/2520582)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #51

Tested manually on a real project